### PR TITLE
build: We don't need anymore build dependencies cairo and cairo-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:centos7
 
-RUN yum -y install createrepo wget bzip2 patch make cmake automake file gcc gcc-c++ gcc-gfortran antlr antlr-C++ libtool texinfo bison flex perl-XML-Parser swig gettext libpng libjpeg-turbo freetype fontconfig jasper-libs cairo pango python-devel zlib-devel libffi-devel readline-devel openssl-devel bzip2-devel libpng-devel libjpeg-turbo-devel freetype-devel fontconfig-devel jasper-devel cairo-devel pango-devel rpm-build xz expat-devel bc which git nspr-devel nss-devel file-devel popt-devel elfutils-devel elfutils elfutils-libelf-devel elfutils-libelf elfutils-libs atlas-devel valgrind
+RUN yum -y install createrepo wget bzip2 patch make cmake automake file gcc gcc-c++ gcc-gfortran antlr antlr-C++ libtool texinfo bison flex perl-XML-Parser swig gettext libpng libjpeg-turbo freetype fontconfig jasper-libs pango python-devel zlib-devel libffi-devel readline-devel openssl-devel bzip2-devel libpng-devel libjpeg-turbo-devel freetype-devel fontconfig-devel jasper-devel pango-devel rpm-build xz expat-devel bc which git nspr-devel nss-devel file-devel popt-devel elfutils-devel elfutils elfutils-libelf-devel elfutils-libelf elfutils-libs atlas-devel valgrind
 
 RUN rpm -qa |sort |md5sum |awk '{print $1;}' >/etc/buildimage_hash


### PR DESCRIPTION
because cairo is now built in mfext